### PR TITLE
Change registrations to Scoped, change connection to localDB, add readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+JumpStart-MVC6WebApi
+====================
+
+Refer to this article:  http://bitoftech.net/2014/11/18/getting-started-asp-net-5-mvc-6-web-api-entity-framework-7/
+
+Also, if you clone this repository, make sure you add a wwwroot folder to your solution.  This folder is required, but due to the project.json approach, this empty folder cannot be checked in to source control (as far as I can tell)
+

--- a/src/Registration_MVC6WebApi/Startup.cs
+++ b/src/Registration_MVC6WebApi/Startup.cs
@@ -26,8 +26,8 @@ namespace Registration_MVC6WebApi
             services.AddMvc();
 
             //Resolve dependency injection
-            services.AddSingleton<IRegistrationRepo, RegistrationRepo>();
-            services.AddSingleton<RegistrationDbContext, RegistrationDbContext>();
+            services.AddScoped<IRegistrationRepo, RegistrationRepo>();
+            services.AddScoped<RegistrationDbContext, RegistrationDbContext>();
         }
         public void Configure(IApplicationBuilder app)
         {

--- a/src/Registration_MVC6WebApi/config.json
+++ b/src/Registration_MVC6WebApi/config.json
@@ -1,7 +1,7 @@
 ﻿{
     "Data": {
         "DefaultConnection": {
-            "Connectionstring": "Data Source=.\\sqlexpress;Initial Catalog=RegistrationDB;Integrated Security=True;"
+            "Connectionstring": "Data Source=(localdb)\\mssqllocaldb;Initial Catalog=RegistrationDB;Integrated Security=True;"
         }
     }
 


### PR DESCRIPTION
Sorry, I think I probably committed a github foul by taking three different things and combining them into one pull request, so feel free to ignore me:

Anyway, the most important part of this pull request is to change the registrations for IRegistrationRepo and RegistrationDbContext to Scoped from Singleton.

Assuming EF7 DbContexts are not thread safe like their EF6 counterparts (http://stackoverflow.com/questions/6126616/is-dbcontext-thread-safe) then I have confirmed that both IRegistrationRepo and RegistrationDbContext need to be registered as Scoped.  Registering the dbcontext as scoped is not enough (as I guessed in my comment posted with the article that references this code).

I confirmed by creating a constructor for RegistrationDbContext (I did not check that change in) and setting a breakpoint on it and then calling the webapi multiple times without shutting it down.  The constructor did not get called per webapi request until both were registered as scoped.

I also changed the default connection to use SQL localDB instead of SQL Express.  SQL localDB is installed with VS 2015 (I assume it is installed with the SQL Data Tools, so make sure you check that installation option)

More info on localDB can be found here: http://msdn.microsoft.com/en-us/library/hh510202.aspx

Finally, I added a basic Readme.MD file
